### PR TITLE
Dtb 20160823

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -44,8 +44,8 @@ OUTDIR=$(readlink -f $OUTDIR)
 
 set-platform
 clean $OUTDIR
-check::deps $PLATFORM $DEPOT_TOOLS_DIR
 check::depot-tools $PLATFORM $DEPOT_TOOLS_URL $DEPOT_TOOLS_DIR
+check::deps $PLATFORM $DEPOT_TOOLS_DIR
 
 # If no revision given, then get the latest revision from git ls-remote
 REVISION=${REVISION:-$(git ls-remote $REPO_URL HEAD | cut -f1)} || \

--- a/build.sh
+++ b/build.sh
@@ -48,7 +48,7 @@ export GYP_MSVS_VERSION='2013'
 echo GYP_MSVS_VERSION $GYP_MSVS_VERSION
 
 set-platform
-#DTB clean $OUTDIR
+clean $OUTDIR
 check::depot-tools $PLATFORM $DEPOT_TOOLS_URL $DEPOT_TOOLS_DIR
 check::deps $PLATFORM $DEPOT_TOOLS_DIR
 

--- a/build.sh
+++ b/build.sh
@@ -42,8 +42,13 @@ PATH=$DEPOT_TOOLS_DIR:$DEPOT_TOOLS_DIR/python276_bin:$PATH
 mkdir -p $OUTDIR
 OUTDIR=$(readlink -f $OUTDIR)
 
+# This is a hack to force use of Microsoft Visual C++ 2013.
+# More sophisticated code would look first for Visual C++ 2015, then 2013.
+export GYP_MSVS_VERSION='2013'
+echo GYP_MSVS_VERSION $GYP_MSVS_VERSION
+
 set-platform
-clean $OUTDIR
+#DTB clean $OUTDIR
 check::depot-tools $PLATFORM $DEPOT_TOOLS_URL $DEPOT_TOOLS_DIR
 check::deps $PLATFORM $DEPOT_TOOLS_DIR
 

--- a/build.sh
+++ b/build.sh
@@ -44,11 +44,10 @@ PATH=$DEPOT_TOOLS_DIR:$DEPOT_TOOLS_DIR/python276_bin:$PATH
 mkdir -p $OUTDIR
 OUTDIR=$(readlink -f $OUTDIR)
 
+# If a Microsoft Visual Studio (C++) version is given, override the Chromium build default.
 if [ -v MSVSVER ]; then
   export GYP_MSVS_VERSION=$MSVSVER
 fi
-
-exit
 
 set-platform
 clean $OUTDIR

--- a/build.sh
+++ b/build.sh
@@ -18,13 +18,15 @@ WebRTC build script.
 
 OPTIONS:
    -h            Show this message
+   -m MSVSVER    Microsoft Visual Studio (C++) version (e.g. 2013). Default is Chromium build default.
    -o OUTDIR     Output directory. Default is 'out'
    -r REVISION   Git SHA revision. Default is latest revision.
 EOF
 }
 
-while getopts :o:r: OPTION; do
+while getopts :m:o:r: OPTION; do
   case $OPTION in
+  m) MSVSVER=$OPTARG ;;
   o) OUTDIR=$OPTARG ;;
   r) REVISION=$OPTARG ;;
   ?) usage; exit 1 ;;
@@ -42,15 +44,16 @@ PATH=$DEPOT_TOOLS_DIR:$DEPOT_TOOLS_DIR/python276_bin:$PATH
 mkdir -p $OUTDIR
 OUTDIR=$(readlink -f $OUTDIR)
 
-# This is a hack to force use of Microsoft Visual C++ 2013.
-# More sophisticated code would look first for Visual C++ 2015, then 2013.
-export GYP_MSVS_VERSION='2013'
-echo GYP_MSVS_VERSION $GYP_MSVS_VERSION
+if [ -v MSVSVER ]; then
+  export GYP_MSVS_VERSION=$MSVSVER
+fi
+
+exit
 
 set-platform
 clean $OUTDIR
+check::deps $PLATFORM
 check::depot-tools $PLATFORM $DEPOT_TOOLS_URL $DEPOT_TOOLS_DIR
-check::deps $PLATFORM $DEPOT_TOOLS_DIR
 
 # If no revision given, then get the latest revision from git ls-remote
 REVISION=${REVISION:-$(git ls-remote $REPO_URL HEAD | cut -f1)} || \

--- a/util.sh
+++ b/util.sh
@@ -169,7 +169,8 @@ function compile() {
     # do the build
     # This is a hack to force use of Microsoft Visual C++ 2013.
     # More sophisticated code would look first for Visual C++ 2015, then 2013.
-    GYP_MSVS_VERSION = '2013'
+    export GYP_MSVS_VERSION='2013'
+    echo GYP_MSVS_VERSION $GYP_MSVS_VERSION
     cmd //c "$WIN_DEPOT_TOOLS\gclient.bat runhooks"
     ninja -C src/out/Debug
     ninja -C src/out/Release

--- a/util.sh
+++ b/util.sh
@@ -167,10 +167,6 @@ function compile() {
   case $platform in
   windows)
     # do the build
-    # This is a hack to force use of Microsoft Visual C++ 2013.
-    # More sophisticated code would look first for Visual C++ 2015, then 2013.
-    export GYP_MSVS_VERSION='2013'
-    echo GYP_MSVS_VERSION $GYP_MSVS_VERSION
     cmd //c "$WIN_DEPOT_TOOLS\gclient.bat runhooks"
     ninja -C src/out/Debug
     ninja -C src/out/Release

--- a/util.sh
+++ b/util.sh
@@ -114,12 +114,14 @@ function patch() {
   case $platform in
   windows)
     # patch for directx not found
-    sed -i 's|\(#include <d3dx9.h>\)|//\1|' $outdir/src/webrtc/modules/video_render/windows/video_render_direct3d9.h
-    sed -i 's|\(D3DXMATRIX\)|//\1|' $outdir/src/webrtc/modules/video_render/windows/video_render_direct3d9.cc
+    # TODO: These files no longer exist
+#    sed -i 's|\(#include <d3dx9.h>\)|//\1|' $outdir/src/webrtc/modules/video_render/windows/video_render_direct3d9.h
+#    sed -i 's|\(D3DXMATRIX\)|//\1|' $outdir/src/webrtc/modules/video_render/windows/video_render_direct3d9.cc
     # patch all platforms to build standalone libs
     find src/webrtc src/talk src/chromium/src/third_party \( -name *.gyp -o  -name *.gypi \) -not -path *libyuv* -exec sed -i "s|\('type': 'static_library',\)|\1 'standalone_static_library': 1,|" '{}' ';'
     # also for the libs that say 'type': '<(component)' like nss and icu
-    find src/chromium/src/third_party src/net/third_party/nss \( -name *.gyp -o  -name *.gypi \) -not -path *libyuv* -exec sed -i "s|\('type': '<(component)',\)|\1 'standalone_static_library': 1,|" '{}' ';'
+    # TODO: These files no longer exist
+    # find src/chromium/src/third_party src/net/third_party/nss \( -name *.gyp -o  -name *.gypi \) -not -path *libyuv* -exec sed -i "s|\('type': '<(component)',\)|\1 'standalone_static_library': 1,|" '{}' ';'
     ;;
   android) ;;
   *)

--- a/util.sh
+++ b/util.sh
@@ -56,10 +56,8 @@ function check::install-package() {
 
 # Makes sure all build dependencies are present.
 # $1: The platform type.
-# $2: The depot tools directory.
 function check::deps() {
   local platform="$1"
-  local depot_tools_dir="$2"
 
   case $platform in
   osx)


### PR DESCRIPTION
This is an update to build.sh and util.sh to build under Microsoft Windows using the git bash shell and Microsoft Visual C++ 2013. The change to force use of Visual C++ 2013 is a hack, and should be improved.

Changes to build.sh:
- Add export GYP_MSVS_VERSION='2013' to force use of Microsoft Visual C++ 2013. This is a hack, and should be improved. GYP_MSVS_VERSION must be defined early in the build process, because it is used before the compile step.
- Call check::depot_tools before check::deps, because check::depot_tools requires that depot_tools be empty, but check::deps loads a file into depot_tools.

Changes to util.sh:
- Recognize $OSTYPE value 'msys' as git bash running under Microsoft Windows, build for Microsoft Windows.
- Run gclient.bat directly, not through schtasks, because schtasks is restricted to use by an administrator.
- Perform mkdir $depot_tools_dir/python276_bin, because curl --create-dirs does not appear to work. Presumably this is a hack that can someday be removed. However, it works and is clear.

As this is written, the compilation does not complete with the current revision of the WebRTC source code. However, that problem is unrelated to these changes.
