### PR TITLE
Migrate to GN build system

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,11 @@ build-webrtc:
   stage: build
   script:
   - ./build.sh $REVISION
+  cache:
+    paths:
+    - out
   artifacts:
+    expire_in: 6 months
     paths:
     - out/*.zip
 
@@ -19,7 +23,7 @@ test-webrtc:
   before_script:
   - apt-get update
   - apt-get install -qq --no-install-recommends unzip pkg-config g++ libssl-dev
-    libnss3-dev
+    libnss3-dev libx11-dev libexpat1-dev libasound2
   script:
   - cd out; unzip *.zip; cd -
   - test/run_tests.sh $(ls -d -1 out/webrtc*/)

--- a/resource/pkgconfig/libwebrtc_full.pc.in
+++ b/resource/pkgconfig/libwebrtc_full.pc.in
@@ -7,4 +7,4 @@ Description: The WebRTC library
 Version: 0.0.1
 Requires: libcrypto, nss
 Cflags: -DWEBRTC_POSIX -I${includedir} -std=gnu++11
-Libs: ${libdir}/$CONFIG/libwebrtc_full.a -ldl
+Libs: ${libdir}/$CONFIG/libwebrtc_full.a -ldl -lX11 -lexpat

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -6,12 +6,22 @@ set -o pipefail
 
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 WEBRTCBUILDS_FOLDER="$1"
-WEBRTCBUILDS_FOLDER=$(readlink -f $WEBRTCBUILDS_FOLDER)
-export PKG_CONFIG_PATH=$WEBRTCBUILDS_FOLDER/lib/Release/pkgconfig
+WEBRTCBUILDS_FOLDER=$(cd $WEBRTCBUILDS_FOLDER && pwd -P)
+CONFIGS="Debug Release"
 
 tmpdir=$(mktemp -d)
 trap 'rm -rf "$tmpdir"' EXIT INT TERM HUP
-pushd $tmpdir
-  c++ -o simple_app $DIR/simple_app.cc -D_GLIBCXX_USE_CXX11_ABI=0 $(pkg-config --cflags --libs --define-variable=WEBRTC_LOCAL=$WEBRTCBUILDS_FOLDER libwebrtc_full) -lpthread
-  ./simple_app
-popd
+pushd $tmpdir >/dev/null
+  for CONFIG in $CONFIGS; do
+    if [[ $(uname) = Linux ]]; then
+      export PKG_CONFIG_PATH=$WEBRTCBUILDS_FOLDER/lib/$CONFIG/pkgconfig
+      c++ -o simple_app $DIR/simple_app.cc $(pkg-config --cflags --libs --define-variable=WEBRTC_LOCAL=$WEBRTCBUILDS_FOLDER libwebrtc_full) -lpthread
+    elif [[ $(uname) = Darwin ]]; then
+      clang++ -o simple_app $DIR/simple_app.cc -DWEBRTC_POSIX -DWEBRTC_MAC -I$WEBRTCBUILDS_FOLDER/include -std=c++11 -stdlib=libc++ $WEBRTCBUILDS_FOLDER/lib/$CONFIG/libwebrtc_full.a -framework Cocoa -framework Foundation -framework IOKit -framework Security -framework SystemConfiguration -framework ApplicationServices -framework CoreServices -framework CoreVideo -framework CoreAudio -framework AudioToolbox -framework QTKit
+    else
+      echo No test currently exists for this platform
+      exit 1
+    fi
+    ./simple_app
+  done
+popd >/dev/null

--- a/test/simple_app.cc
+++ b/test/simple_app.cc
@@ -1,10 +1,27 @@
-#include "webrtc/base/ssladapter.h"
 #include "webrtc/base/thread.h"
+#include "webrtc/p2p/base/basicpacketsocketfactory.h"
+#include "webrtc/api/peerconnectioninterface.h"
+#include "webrtc/api/test/fakeconstraints.h"
+#include "webrtc/media/engine/webrtcvideocapturerfactory.h"
 
 int main(int argc, char* argv[]) {
-  rtc::AutoThread auto_thread;
+  // something from base
   rtc::Thread* thread = rtc::Thread::Current();
-  rtc::InitializeSSL();
-  rtc::CleanupSSL();
+
+  // something from p2p
+  std::unique_ptr<rtc::BasicPacketSocketFactory> socket_factory(
+    new rtc::BasicPacketSocketFactory());
+
+  // something from api
+  rtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface>
+    peer_connection_factory = webrtc::CreatePeerConnectionFactory();
+
+  // something from api/test
+  webrtc::FakeConstraints constraints;
+
+  // something from media/engine
+  cricket::WebRtcVideoDeviceCapturerFactory factory;
+  cricket::VideoCapturer* capturer = factory.Create(cricket::Device("", 0));
+
   return 0;
 }


### PR DESCRIPTION
Compilation is done with is_component_build=false and
rtc_include_tests=false then the resulting objects are combined
into one static library by parsing the .ninja_deps file for object
files. Objects related to intrinsics had to be added seperately,
unclear why.
On Linux, override the default clang-based toolchain build to
default to building with gcc.
Add helpful build progress messages, reduce logging noise.
Expand simple test app and test more than one configuration.
Remove the need for 'gsed' on OSX.
