### PR TITLE
Better handle linux dependencies

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,5 @@
 before_script:
+- sed -i "s#universe#universe multiverse#" /etc/apt/sources.list
 - apt-get update
 - apt-get install -qq --no-install-recommends ca-certificates
 

--- a/build.sh
+++ b/build.sh
@@ -53,8 +53,8 @@ fi
 set-platform
 echo "Platform set: $PLATFORM"
 
-echo Checking dependencies
-check::deps $PLATFORM
+echo Checking webrtcbuilds dependencies
+check::webrtcbuilds::deps $PLATFORM
 
 echo Checking depot-tools
 check::depot-tools $PLATFORM $DEPOT_TOOLS_URL $DEPOT_TOOLS_DIR
@@ -69,6 +69,9 @@ echo "Associated revision number: $REVISION_NUMBER"
 
 echo "Checking out WebRTC revision (this will take awhile): $REVISION"
 checkout $PLATFORM $OUTDIR $REVISION
+
+echo Checking WebRTC dependencies
+check::webrtc::deps $PLATFORM $OUTDIR
 
 echo Patching WebRTC source
 patch $PLATFORM $OUTDIR


### PR DESCRIPTION
Broke deps into two parts: one for webrtcbuilds, one for webrtc
Use a webrtc/chromium provided install deps script. This is only
available after the initial fetch/checkout.
