### PR TITLE
Rewrite Microsoft Windows build to use gn and match other builds.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -18,18 +18,18 @@ WebRTC build script.
 
 OPTIONS:
    -h             Show this message
-   -m MSVSVER     Microsoft Visual Studio (C++) version (e.g. 2013). Default is Chromium build default.
    -o OUTDIR      Output directory. Default is 'out'
+   -b BRANCH     Latest revision on git branch. Overrides -r. Common branch names are 'branch-heads/nn', where 'n' is the release number.
    -r REVISION    Git SHA revision. Default is latest revision.
    -t TARGET OS   The target os for cross-compilation. Default is the host OS such as 'linux', 'mac', 'win'. Other values can be 'android', 'ios'.
    -c TARGET CPU  The target cpu for cross-compilation. Default is 'x64'. Other values can be 'x86', 'arm64', 'arm'.
 EOF
 }
 
-while getopts :m:o:r:t:c: OPTION; do
+while getopts :b:o:r:t:c: OPTION; do
   case $OPTION in
-  m) MSVSVER=$OPTARG ;;
   o) OUTDIR=$OPTARG ;;
+  b) BRANCH=$OPTARG ;;
   r) REVISION=$OPTARG ;;
   t) TARGET_OS=$OPTARG ;;
   c) TARGET_CPU=$OPTARG ;;
@@ -38,6 +38,7 @@ while getopts :m:o:r:t:c: OPTION; do
 done
 
 OUTDIR=${OUTDIR:-out}
+BRANCH=${BRANCH:-}
 PROJECT_NAME=webrtcbuilds
 REPO_URL="https://chromium.googlesource.com/external/webrtc"
 DEPOT_TOOLS_URL="https://chromium.googlesource.com/chromium/tools/depot_tools.git"
@@ -47,12 +48,6 @@ PATH=$DEPOT_TOOLS_DIR:$DEPOT_TOOLS_DIR/python276_bin:$PATH
 
 mkdir -p $OUTDIR
 OUTDIR=$(cd $OUTDIR && pwd -P)
-
-# If a Microsoft Visual Studio (C++) version is given, override the Chromium build default.
-MSVSVER=${MSVSVER:-}
-if [ -n "$MSVSVER" ]; then
-  export GYP_MSVS_VERSION=$MSVSVER
-fi
 
 detect-platform
 TARGET_OS=${TARGET_OS:-$PLATFORM}
@@ -67,12 +62,17 @@ check::webrtcbuilds::deps $PLATFORM
 echo Checking depot-tools
 check::depot-tools $PLATFORM $DEPOT_TOOLS_URL $DEPOT_TOOLS_DIR
 
-# If no revision given, then get the latest revision from git ls-remote
-REVISION=${REVISION:-$(latest-rev $REPO_URL)} || \
-  { echo "Could not get latest revision" && exit 1; }
+if [ ! -z $BRANCH ]; then
+  REVISION=$(git ls-remote $REPO_URL --heads $BRANCH | head --lines 1 | cut --fields 1) || \
+    { echo "Cound not get branch revision" && exit 1; }
+   echo "Building branch: $BRANCH"
+else
+  REVISION=${REVISION:-$(latest-rev $REPO_URL)} || \
+    { echo "Could not get latest revision" && exit 1; }
+fi
+echo "Building revision: $REVISION"
 REVISION_NUMBER=$(revision-number $REPO_URL $REVISION) || \
   { echo "Could not get revision number" && exit 1; }
-echo "Building revision: $REVISION"
 echo "Associated revision number: $REVISION_NUMBER"
 
 echo "Checking out WebRTC revision (this will take awhile): $REVISION"


### PR DESCRIPTION
This update has the following changes:

build.sh:
- added '-b' to fetch a branch by name
- removed Microsoft Visual C++ version option, since the WebRTC build supports only Microsoft Visual C++ 2015

util.sh
- added a Microsoft Windows build function to use 'gn', matching the other builds
- no changes to builds for hosts other than Microsoft Windows

Unfortunately, I can only partially test the Microsoft Windows build, because my Microsoft Windows development system encounters an error in landmines.py. This is unrelated to the script, I see the same error when building manually. When I have a chance, I will test using a clean Windows install.
