### PR TITLE
Fix markdown rendering in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@ package for WebRTC.
 ## Current Platforms and Prerequisites
 
 * OSX (highly recommend [Homebrew](http://brew.sh/) is installed)
-* Windows (highly recommend [Visual Studio Community 2013]
-(http://www.chromium.org/developers/how-tos/build-instructions-windows) at least
+* Windows (highly recommend [Visual Studio Community 2013](http://www.chromium.org/developers/how-tos/build-instructions-windows) at least
 and a [Bash shell such as Git for Windows](https://msysgit.github.io) is
 installed)
 * Linux (tested on Ubuntu 16.04 64-bit)


### PR DESCRIPTION
This pr fixes an issue in which the "Visual Studio Community 2013" link in the top-level README.md was not being rendered correctly due to some extra whitespace.