### PR TITLE
Miscellaneous changes

### DIFF
--- a/util.sh
+++ b/util.sh
@@ -230,7 +230,7 @@ function compile() {
   local outdir="$2"
   local target_os="$3"
   local target_cpu="$4"
-  local common_args="is_component_build=false rtc_include_tests=false"
+  local common_args="is_component_build=false rtc_include_tests=false treat_warnings_as_errors=false"
   local target_args="target_os=\"$target_os\" target_cpu=\"$target_cpu\""
 
   pushd $outdir/src >/dev/null

--- a/util.sh
+++ b/util.sh
@@ -157,10 +157,6 @@ function patch() {
   pushd $outdir/src >/dev/null
   # This removes the examples from being built.
   sed -i.bak 's|"//webrtc/examples",|#"//webrtc/examples",|' BUILD.gn
-  # This patches a GN error with the video_loopback executable depending on a
-  # test but since we disable building tests GN detects a dependency error.
-  # Replacing the outer conditional with 'rtc_include_tests' works around this.
-  sed -i.bak 's|if (!build_with_chromium)|if (rtc_include_tests)|' webrtc/BUILD.gn
   popd >/dev/null
 }
 

--- a/util.sh
+++ b/util.sh
@@ -312,6 +312,11 @@ function package() {
   pushd $outdir >/dev/null
   # create directory structure
   mkdir -p $label/include $label/lib
+  local configs="Debug Release"
+  for cfg in $configs; do
+    mkdir -p $label/lib/$cfg
+  done
+
   # find and copy header files
   pushd src >/dev/null
   find webrtc -name *.h -exec $CP --parents '{}' $outdir/$label/include ';'
@@ -324,7 +329,6 @@ function package() {
 
   # for linux, add pkgconfig files
   if [ $platform = 'linux' ]; then
-    configs="Debug Release"
     for cfg in $configs; do
       mkdir -p $label/lib/$cfg/pkgconfig
       CONFIG=$cfg envsubst '$CONFIG' < $resourcedir/pkgconfig/libwebrtc_full.pc.in > \

--- a/util.sh
+++ b/util.sh
@@ -157,6 +157,9 @@ function patch() {
   pushd $outdir/src >/dev/null
   # This removes the examples from being built.
   sed -i.bak 's|"//webrtc/examples",|#"//webrtc/examples",|' BUILD.gn
+  # Force a RTTI build.
+  sed -i.bak 's|"//build/config/compiler:no_rtti",|"//build/config/compiler:rtti",|' \
+    build/config/BUILDCONFIG.gn
   popd >/dev/null
 }
 


### PR DESCRIPTION
Disable warnings as error to deal with deprecation warnings that prevented the build.
A minor change to create the directories first instead of copy permissions from the build directories. 
Removes an old workaround that fixed issue #39.
Forcing RTTI builds, maybe you want to make this optional somehow.
I'd refactored a little the code to make windows and non windows more similar and remove some duplicated code.

