### PR TITLE
Fix overzealous blacklisting with 'tools'

### DIFF
--- a/util.sh
+++ b/util.sh
@@ -218,7 +218,7 @@ device_info_external.obj"
 function compile-unix() {
   local outputdir="$1"
   local gn_args="$2"
-  local blacklist="unittest|examples|tools|/yasm|protobuf_lite|main.o|\
+  local blacklist="unittest|examples|/yasm|protobuf_lite|main.o|\
 video_capture_external.o|device_info_external.o"
 
   gn gen $outputdir --args="$gn_args"


### PR DESCRIPTION
'tools' was preventing the 'rtc_tools' objects from being added to the
archive. From the list of objects, it appears 'rtc_tools' are the only
objects related to tools being added so removing 'tools' altogether.