### PR TITLE
Update travis-ci osx version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: required
 os:
 - linux
 - osx
+osx_image: xcode9.3
 addons:
   apt:
     sources:
@@ -34,8 +35,3 @@ script:
   sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 90 --slave /usr/bin/g++ g++ /usr/bin/g++-5;
   fi
 - test/run_tests.sh $(ls -d -1 out/webrtc*/) Release
-# Allow failures on osx until the travis osx pipeline is more robust.
-matrix:
-  fast_finish: true
-  allow_failures:
-  - os: osx


### PR DESCRIPTION
Remove allow_failures on osx because of improved ci robustness